### PR TITLE
Add reusable workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,187 @@
+# markbind-reusable-workflows
+
+A list of GitHub Reusable Workflows that help improve your CI/CD with a MarkBind site.
+
+- Create a new workflow to preview proposed changes to your MarkBind site, including PRs from forks
+  - `fork-build.yml`
+  - `fork-preview.yml`
+- Unpublish PR preview site
+  - `unpublish-preview.yml`
+
+## Option Summary
+
+### fork-build
+
+Option                                                 | Required |                      Default | Remarks
+:------------------------------------------------------|:--------:|-----------------------------:|----------------------------------------------
+[version](#version)                                    |    no    |                   `'latest'` | The MarkBind version to use to build the site
+[rootDirectory](#rootdirectory-markbind-cli-arguments) |    no    |                        `'.'` | The directory to read source files from
+[siteConfig](#siteconfig-markbind-cli-arguments)       |    no    |                `'site.json'` | The site config file to use
+
+### fork-preview & unpublish-preview
+
+Option            | Required | Remarks
+:-----------------|:--------:|-----------------------------------------
+[token](#token)   |   yes    | The token to be used for the service
+[domain](#domain) |   yes    | The domain that the site is available at
+
+## Option Details
+
+### version
+
+The MarkBind version to use to build the site.
+
+- Latest
+  - `'latest'`
+  - This is the latest published version of MarkBind
+- Development
+  - `'development'`
+  - This is the latest, possibly unpublished version of MarkBind in development
+- Any valid version
+  - `'X.Y.Z'`
+  - This is the version of MarkBind with the specified version number
+  - E.g. `'3.1.1'`
+- Any valid version range
+  - Internally the action calls [`npm install`](https://docs.npmjs.com/cli/v6/commands/npm-install) to install the specified version of MarkBind
+  - Hence, a version range such as `'>=3.0.0'` (or semantic versioning like `'^3.1.1'`) is also valid
+
+### rootDirectory (MarkBind CLI arguments)
+
+The directory to read source files from.
+
+- Root
+  - `'.'`
+  - This is the default value
+  - This is for the case that your source files of the MarkBind site are in the root directory of the repository
+- Any subdirectory
+  - `'./path/to/directory'`
+  - This is for the case that your source files of the MarkBind site are in a subdirectory of the repository
+    - E.g. `'./docs'`
+
+### siteConfig (MarkBind CLI arguments)
+
+The site config file to use.
+
+- Default site config file
+  - `'site.json'`
+  - This is the default value
+- Name of your site config file
+  - If your site config file is not named `site.json`, specify the name here
+    - E.g. `'ug-site.json'`
+
+### token
+
+Token for Surge.sh
+
+- `${{ secrets.SURGE_TOKEN }}`
+  - `SURGE_TOKEN` is the environment secret name
+- Require registration with an email address
+- After retrieving the token, put the token as a repository secret in your repository
+- See [here](https://markbind.org/userGuide/deployingTheSite.html#previewing-prs-using-surge) for a detailed guide on how to retrieve the token
+
+### domain
+
+The domain that the site is available at.
+
+- A surge.sh subdomain
+  - `'<subDomain>.surge.sh'`
+  - Surge allows you to specify a subdomain for free as long as it has not been taken up by others. You have to ensure that the `<subDomain>` is unique.
+  - A possible subdomain to use is your repository name: e.g. `mb-test.surge.sh`
+- Additional notes
+  - for PR preview purposes, the domain you specify will automatically be prefixed with 'pr-x-', where 'x' is the GitHub event number
+    - E.g. `'pr-x-<domain>'` (and hence `'pr-1-mb-test.surge.sh'`)
+  - Custom domain does not work with PR preview
+  - This action will not automatically cleanup merged PR deployments. Follow this [instruction](https://surge.sh/help/tearing-down-a-project) to manually tear down the deployed site if required
+
+## Usage
+
+With `fork-build.yml` and `fork-preview.yml`, you can establish a secure workflow that builds your MarkBind site triggered by a fork PR.
+Then, the site artifact will be uploaded and deployed for preview. Note that the choice of using two separate workflows is to reduce possible security issues, as [recommended](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) by the GitHub Security Lab.
+
+In your repository, you will need to add two workflows to the `.github/workflows` folder.
+
+- The first workflow being `fork-build.yml` will be triggered by a pull request.
+  - Adjust the target branch accordingly
+    - The sample workflow below will be triggered by PR against the `main` branch
+- The second workflow being `fork-preview.yml` will be triggered whenever `fork-build` is completed.
+  - Adjust the domain accordingly
+    - The sample workflow below publish to `pr-x-mb-test.surge.sh`
+
+1. Create a `fork-build.yml`
+
+```yaml
+name: Build Fork PR
+
+# read-only
+# no access to secrets
+on:
+  pull_request:
+    branches:
+      - main
+
+# cancel multiple runs at the same time, can be removed if you don't want it
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Fork PR
+    uses: MarkBind/markbind-action/.github/workflows/fork-build.yml@master
+    with:
+      version: "3.1.1"
+```
+
+2. Create a `fork-preview.yml`
+
+```yaml
+name: Preview Fork PR
+
+on:
+  workflow_run:
+    workflows: ["Build Fork PR"]
+    types: [completed]
+
+jobs:
+  on-success:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Deploying to Surge
+    uses: MarkBind/markbind-action/.github/workflows/fork-preview.yml@master
+    with:
+      domain: "mb-test.surge.sh"
+    secrets:
+      token: ${{ secrets.SURGE_TOKEN }}
+```
+
+### Unpublish PR preview site
+
+*(This is Optional)*
+
+By default, the site will be published to surge.sh and will be available for preview. These site will not be deleted when the PR is merged. However, if you wish to unpublish the site whenever the PR is merged/closed, you can use the following workflow.
+
+Note that this workflow uses the `pull_request_target` in order to expose the secrets to the workflow triggered by a fork. This is still secure (admittedly, not as secure as not exposing the secrets at all) as the workflow does not require dangerous processing, say building or running the content of the PR. Read [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) if you want to learn more about this.
+
+You may also consider manually teardown a surge site by following the [instruction](https://surge.sh/help/tearing-down-a-project), if required.
+
+1. Create a `unpublish-preview.yml`
+   - Adjust the target branch accordingly
+      - The sample workflow below will be triggered by PR against the `main` branch
+
+```yaml
+name: Unpublish preview site
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Unpublish from Surge
+    uses: MarkBind/markbind-action/.github/workflows/unpublish-preview.yml@master
+    with:
+      domain: "mb-test.surge.sh"
+    secrets:
+      token: ${{ secrets.SURGE_TOKEN }}
+```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 A list of GitHub Reusable Workflows that help improve your CI/CD with a MarkBind site.
 
-- Create a new workflow to preview proposed changes to your MarkBind site, including PRs from forks
+- Create a new workflow to set up PR preview for your MarkBind site, including PRs from forks
   - `fork-build.yml`
   - `fork-preview.yml`
 - Unpublish PR preview site
@@ -33,6 +33,7 @@ The MarkBind version to use to build the site.
 
 - Latest
   - `'latest'`
+  - This is the default value
   - This is the latest published version of MarkBind
 - Development
   - `'development'`
@@ -157,11 +158,11 @@ jobs:
 
 *(This is Optional)*
 
-By default, the site will be published to surge.sh and will be available for preview. These site will not be deleted when the PR is merged. However, if you wish to unpublish the site whenever the PR is merged/closed, you can use the following workflow.
+By default, the site will be published to surge.sh and will be available for preview. The site will not be deleted when the PR is merged. However, if you wish to unpublish the site whenever the PR is merged/closed, you can use the following workflow.
 
 Note that this workflow uses the `pull_request_target` in order to expose the secrets to the workflow triggered by a fork. This is still secure (admittedly, not as secure as not exposing the secrets at all) as the workflow does not require dangerous processing, say building or running the content of the PR. Read [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) if you want to learn more about this.
 
-You may also consider manually teardown a surge site by following the [instruction](https://surge.sh/help/tearing-down-a-project), if required.
+You may also consider a manual teardown of a surge site by following the [instruction](https://surge.sh/help/tearing-down-a-project), if required.
 
 1. Create a `unpublish-preview.yml`
    - Adjust the target branch accordingly

--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -30,6 +30,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 12
+      - name: Install Graphviz
+        run: sudo apt-get install graphviz
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
       - name: Checkout markbind-cli@master
         if: inputs.version == 'development'
         uses: actions/checkout@v3

--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -1,0 +1,80 @@
+name: Build site from Fork
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: the version of MarkBind to use. e.g. 3.1.1
+        default: 'latest'
+        type: string
+      rootDirectory:
+        description: read source files from the specified directory
+        default: '.'
+        type: string
+      siteConfig:
+        description: the site config file to use
+        default: 'site.json'
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: curr-repo
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - name: Checkout markbind-cli@master
+        if: inputs.version == 'development'
+        uses: actions/checkout@v3
+        with:
+          repository: MarkBind/markbind
+          path: markbind-cli
+      - name: Install markbind-cli@master
+        if: inputs.version == 'development'
+        run: |
+          npm i -g npm@8.3.1
+          cd markbind-cli
+          npm run setup && npm run build:web
+          cd packages/cli
+          npm link
+          cd ../../..
+      - name: Install a released version of markbind-cli
+        if: inputs.version != 'development'
+        run: |
+          npm install -g markbind-cli@${{ inputs.version }}
+      - name: Build site
+        run: |
+          cd curr-repo
+          markbind build ${{ inputs.rootDirectory }} ./_site \
+          --baseUrl --site-config ${{ inputs.siteConfig }}
+          cd ..
+          echo "Site Built!"
+      - name: Check build status
+        run: |
+          if [ ! -d "./curr-repo/_site" ]; then
+            echo "Build Error"
+            exit 1
+          fi
+      - name: Save PR number and HEAD commit
+        if: ${{ success() && github.event_name == 'pull_request' }}
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NUMBER
+          echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
+      - name: Upload artifacts
+        if: ${{ success() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: site-artifacts
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            ./curr-repo/_site
+            ./pr

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -1,0 +1,60 @@
+name: Preview site from Fork
+
+on:
+  workflow_call:
+    secrets:
+      token: # SURGE_TOKEN
+        description: the token for deployment service
+        required: true
+    inputs:
+      domain:
+        description: the domain to use
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Deploying to surge
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download built site artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: fork-build.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: site-artifacts
+          path: .
+      - name: Extract PR number
+        id: pr-number
+        run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - name: Build PR preview url
+        id: pr-url
+        run: |
+          PR_URL="https://pr-${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}-${{ inputs.domain }}"
+          echo '::set-output name=ACTIONS_PREVIEW_URL::'$PR_URL
+      - name: Install surge and deploy PR to surge
+        run: |
+          npm i -g surge
+          surge --project ./curr-repo/_site --domain ${{ steps.pr-url.outputs.ACTIONS_PREVIEW_URL }}
+        env:
+          SURGE_TOKEN: ${{ secrets.token }}
+      - name: Find existing PR preview link comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}
+          body-includes: Your PR can be previewed
+      - name: Comment PR preview link in PR
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}
+          body: |
+            Thank you for submitting the Pull Request! :thumbsup: 
+
+            Your PR can be previewed [here](${{ steps.pr-url.outputs.ACTIONS_PREVIEW_URL }})

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -1,0 +1,47 @@
+name: Unpublish preview site
+
+on:
+  workflow_call:
+    secrets:
+      token: # SURGE_TOKEN
+        description: the token for deployment service
+        required: true
+    inputs:
+      domain:
+        description: the domain to use
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Unpublish from Surge
+    steps:
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - name: Build PR preview url
+        id: pr-url
+        run: |
+          PR_URL="https://pr-${{ github.event.number }}-${{ inputs.domain }}"
+          echo '::set-output name=ACTIONS_PREVIEW_URL::'$PR_URL
+      - name: Install surge and teardown
+        run: |
+          npm i -g surge
+          surge teardown --domain ${{ steps.pr-url.outputs.ACTIONS_PREVIEW_URL }}
+        env:
+          SURGE_TOKEN: ${{ secrets.token }}
+      - name: Find existing PR preview link comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Your PR preview site has been torn down
+      - name: Comment PR preview torn down in PR
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            Your PR preview site has been torn down

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # markbind-action
 A GitHub Action that builds and deploys your MarkBind site.
 
+- See [markbind-reusable-workflows](.github/workflows/README.md) for more details on a list of utilities that can be used to improve your CI/CD with a MarkBind site.
+
 ## Option Summary
 
 Option                  | Required |        Default | Remarks


### PR DESCRIPTION
Result of https://github.com/MarkBind/markbind/pull/1853

Proposed commit message:
Add reusable workflows

Setting up CI/CD pipeline for PR preview of a MarkBind site
can be troublesome. The workflow required to setup PR
previews from forks requires more complex configuration.

Let's include a list of reusable workflows that MarkBind users
can easily reuse to setup their CI/CD pipeline efficiently.

This allows for less steps required in the host's workflow as
the bulk of the work is provided by the scripts here.

Additional workflow is also included to help users who wish
to automatically unpublish a PR preview site.