### PR TITLE
Update nodejs version for MarkBind v4 release

### DIFF
--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: the version of MarkBind to use. e.g. 3.1.1
+        description: the version of MarkBind to use. e.g. 4.0.0
         default: 'latest'
         type: string
       rootDirectory:
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Install Graphviz
         run: sudo apt-get install graphviz
       - name: Install Java

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The domain that the site is available at. Required if `service` chosen is Surge.
 The MarkBind version to use to build the site.
 - Latest
   - `'latest'`
-  - This is the latest published version of MarkBind
+  - This is the [latest published](https://www.npmjs.com/package/markbind-cli) version of MarkBind
 - Development
   - `'development'`
   - This is the latest, possibly unpublished version of MarkBind in development
@@ -164,9 +164,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           baseUrl: '/mb-test'
-          version: '3.1.1'
+          version: '4.0.0'
 ```
-The above script builds the site from the repository's root directory, with `baseUrl` of '/mb-test' ('mb-test' is the repository name), with MarkBind version 3.1.1.
+The above script builds the site from the repository's root directory, with `baseUrl` of '/mb-test' ('mb-test' is the repository name), with MarkBind version `4.0.0`.
 
 Then, it will deploy the site to GitHub Pages. It runs everytime there is a push to the repository's master branch.
 
@@ -188,7 +188,7 @@ jobs:
         uses: MarkBind/markbind-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: '3.1.1'
+          version: '4.0.0'
 ```
 
 For GitHub Pages, you will need to specify the `baseUrl` either as an input in the workflow file or in the site config file(`site.json`), in order to configure the relative URL correctly.

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: the domain to use
     type: string
   version:
-    description: the MarkBind version to use. e.g. 3.1.1
+    description: the MarkBind version to use. e.g. 4.0.0
     default: 'latest'
     type: string
   rootDirectory:
@@ -50,7 +50,7 @@ runs:
     - name: Install Node
       uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: 14
     - name: Checkout markbind-cli@master
       if: inputs.version == 'development'
       uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #5

```
Update nodejs version for MarkBind V4

Since the release of MarkBind V4, nodejs version has been
updated to V14.

Let's update the action configurations to install nodejs V14.

This will make the action compatible with future MarkBind V4
version updates.
```

