### PR TITLE
Update node version from 14 to 16

### DIFF
--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Install markbind-cli@master
         if: inputs.version == 'development'
         run: |
-          npm i -g npm@8.19.3
           cd markbind-cli
           npm run setup && npm run build:web
           cd packages/cli

--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Graphviz
         run: sudo apt-get install graphviz
       - name: Install Java
@@ -46,7 +46,7 @@ jobs:
       - name: Install markbind-cli@master
         if: inputs.version == 'development'
         run: |
-          npm i -g npm@8.3.1
+          npm i -g npm@8.19.3
           cd markbind-cli
           npm run setup && npm run build:web
           cd packages/cli

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,6 @@ runs:
     - name: Install markbind-cli@master
       if: inputs.version == 'development'
       run: |
-        npm i -g npm@8.19.3
         cd markbind-cli
         npm run setup && npm run build:web
         cd packages/cli

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Install Node
       uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 16
     - name: Checkout markbind-cli@master
       if: inputs.version == 'development'
       uses: actions/checkout@v3
@@ -60,7 +60,7 @@ runs:
     - name: Install markbind-cli@master
       if: inputs.version == 'development'
       run: |
-        npm i -g npm@8.3.1
+        npm i -g npm@8.19.3
         cd markbind-cli
         npm run setup && npm run build:web
         cd packages/cli


### PR DESCRIPTION
Update nodejs version

As nodejs V14 is coming to its end of life, nodejs version has been
updated to V16.

Let's update the action configurations to install nodejs V16

This will make the action compatible with future MarkBind V5
version updates.