### PR TITLE
Replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -51,7 +51,7 @@ jobs:
           body-includes: Your PR can be previewed
       - name: Comment PR preview link in PR
         if: ${{ steps.fc.outputs.comment-id == 0 }}
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}
           body: |

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -27,7 +27,7 @@ jobs:
           path: .
       - name: Extract PR number
         id: pr-number
-        run: echo "ACTIONS_PR_NUMBER=${$(cat ./pr/NUMBER)}" >> $GITHUB_OUTPUT
+        run: echo "ACTIONS_PR_NUMBER=${cat ./pr/NUMBER}" >> $GITHUB_OUTPUT
 #        run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
       - name: Install Node
         uses: actions/setup-node@v2

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -27,7 +27,8 @@ jobs:
           path: .
       - name: Extract PR number
         id: pr-number
-        run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
+        run: echo "ACTIONS_PR_NUMBER=${$(cat ./pr/NUMBER)}" >> $GITHUB_OUTPUT
+#        run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
       - name: Install Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -27,7 +27,7 @@ jobs:
           path: .
       - name: Extract PR number
         id: pr-number
-        run: echo "ACTIONS_PR_NUMBER=${cat ./pr/NUMBER}" >> $GITHUB_OUTPUT
+        run: echo "ACTIONS_PR_NUMBER=$(cat ./pr/NUMBER)" >> $GITHUB_OUTPUT
 #        run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
       - name: Install Node
         uses: actions/setup-node@v2

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           SURGE_TOKEN: ${{ secrets.token }}
       - name: Find existing PR preview link comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v2
         id: fc
         with:
           issue-number: ${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           PR_URL="https://pr-${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}-${{ inputs.domain }}"
           echo "ACTIONS_PREVIEW_URL=${PR_URL}" >> $GITHUB_OUTPUT
-#          echo '::set-output name=ACTIONS_PREVIEW_URL::'$PR_URL
       - name: Install surge and deploy PR to surge
         run: |
           npm i -g surge

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Extract PR number
         id: pr-number
         run: echo "ACTIONS_PR_NUMBER=$(cat ./pr/NUMBER)" >> $GITHUB_OUTPUT
-#        run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
       - name: Install Node
         uses: actions/setup-node@v2
         with:
@@ -37,7 +36,8 @@ jobs:
         id: pr-url
         run: |
           PR_URL="https://pr-${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}-${{ inputs.domain }}"
-          echo '::set-output name=ACTIONS_PREVIEW_URL::'$PR_URL
+          echo "ACTIONS_PREVIEW_URL=${PR_URL}" >> $GITHUB_OUTPUT
+#          echo '::set-output name=ACTIONS_PREVIEW_URL::'$PR_URL
       - name: Install surge and deploy PR to surge
         run: |
           npm i -g surge

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -25,7 +25,7 @@ jobs:
         id: pr-url
         run: |
           PR_URL="https://pr-${{ github.event.number }}-${{ inputs.domain }}"
-          echo '::set-output name=ACTIONS_PREVIEW_URL::'$PR_URL
+          echo "ACTIONS_PREVIEW_URL=${PR_URL}" >> $GITHUB_OUTPUT
       - name: Install surge and teardown
         run: |
           npm i -g surge

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           SURGE_TOKEN: ${{ secrets.token }}
       - name: Find existing PR preview link comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v2
         id: fc
         with:
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -40,7 +40,7 @@ jobs:
           body-includes: Your PR preview site has been torn down
       - name: Comment PR preview torn down in PR
         if: ${{ steps.fc.outputs.comment-id == 0 }}
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.number }}
           body: |

--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
         body-includes: Your PR can be previewed
     - name: Comment PR preview link in PR
       if: inputs.service == 'surge' && inputs.purpose == 'pr-preview' && github.event_name == 'pull_request' && steps.fc.outputs.comment-id == 0
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ env.prNum }}
         body: |

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
         SURGE_TOKEN: ${{ inputs.token }}
     - name: Find existing PR preview link comment
       if: inputs.service == 'surge' && inputs.purpose == 'pr-preview' && github.event_name == 'pull_request'
-      uses: peter-evans/find-comment@v1
+      uses: peter-evans/find-comment@v2
       id: fc
       with:
         issue-number: ${{ env.prNum }}


### PR DESCRIPTION
Resolves #9 and Resolves #12

As set-output and save-state is set to be [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), let's get rid of it before it is deprecated.
Markbind actions only uses set-output

**Overview of changes**
Change set-output to use GITHUB_OUTPUT instead. 

**Testing instructions**
1. Make repo using markbind init or use existing repo. 
2. Add `fork-build.yml`, `fork-preview.yml` and `unpublish-preview.yml` according to [README ](https://github.com/MarkBind/markbind-action/blob/master/.github/workflows/README.md)in reusable workflows. 
3. Change the `uses` to `yucheng11122017/markbind-action/.github/workflows/{FILE_NAME}@replaceSetOutput` for each of the above files
4. Create a new pull request to main branch (or change the name of branch in workflow to the branch you make a PR to)
5. Check logs that the PR number and PR URL of the deployed site is as expected. 
6. Close PR to trigger `unpublish-preview.yml`
7. Check action logs to check that the correct URL is being torn down 
8. Check that site is actually torn down by going to the site and seeing project not found error

**Proposed commit message**
Replace deprecated set-output with GITHUB_OUTPUT

