### PR TITLE
Upgrade setup-node to v3 from v2

### DIFF
--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: curr-repo
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Install Graphviz

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -29,7 +29,7 @@ jobs:
         id: pr-number
         run: echo "ACTIONS_PR_NUMBER=$(cat ./pr/NUMBER)" >> $GITHUB_OUTPUT
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Build PR preview url

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -18,7 +18,7 @@ jobs:
     name: Unpublish from Surge
     steps:
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Build PR preview url

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
       with:
         path: curr-repo
     - name: Install Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
     - name: Checkout markbind-cli@master


### PR DESCRIPTION
Resolves #11 

**Overview of changes**
Upgrade setup-node to v3 from v2 to align with version in main repo

**Proposed commit message**
Upgrade setup-node to v3 from v2

Workflow logs for checking: 
`action.yml`: https://github.com/yucheng11122017/markbind-init-trial/actions/runs/4701399650
`fork-build.yml`: https://github.com/yucheng11122017/markbind-init-trial/actions/runs/4701476988
`fork-preview.yml`: https://github.com/yucheng11122017/markbind-init-trial/actions/runs/4701486380
`unpublish-preview.yml`: https://github.com/yucheng11122017/markbind-init-trial/actions/runs/4701531050/jobs/8337668315