### PR TITLE
Update MarkBind Action node version to 18

### DIFF
--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Install Graphviz
         run: sudo apt-get install graphviz
       - name: Install Java

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Install Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - name: Checkout markbind-cli@master
       if: inputs.version == 'development'
       uses: actions/checkout@v3


### PR DESCRIPTION
Update Node 16 to 18

As nodejs V16 has reached end of life. Let's update the GitHub Action configurations to install Node 18

Related: [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

--- 

Note: the current release is operating on Node 14, making a new release to reflect the latest node version is needed.
* See https://github.com/gerteck/mb-test-deploy/actions/runs/10439400945/job/28907978834
* https://github.com/marketplace/actions/markbind-action

For [markbind-reusable-workflows](https://markbind.org/devdocs/devGuide/githubActions/markbindReusableWorkflows.html)
> As there is no need to release the reusable workflows in order for others to use, the workflows will be updated and maintained in the master branch (without doing a release).