### PR TITLE
Update MarkBind Action node version to 22

### DIFF
--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - name: Install Graphviz
         run: sudo apt-get install graphviz
       - name: Install Java

--- a/.github/workflows/fork-preview.yml
+++ b/.github/workflows/fork-preview.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/.github/workflows/unpublish-preview.yml
+++ b/.github/workflows/unpublish-preview.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - name: Build PR preview url
         id: pr-url
         run: |

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Install Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 22
     - name: Checkout markbind-cli@master
       if: inputs.version == 'development'
       uses: actions/checkout@v3


### PR DESCRIPTION
Workflow uses node18.

Node18's last update was Mar 2025, and
is now EOL.

Change node version to 22 (LTS)

Skip version 20 as v20 is EOL in 2 months.

-------

* Here's a workflow run that shows it working on node 22:
https://github.com/Harjun751/CS2109S-notes/actions/runs/22172356653/job/64112821666

-----
Related PRs:
Markbind/init-typical-netlify#7
Markbind/init-minimal-netlify#7
Markbind/markbind#2838